### PR TITLE
アウトプット投稿機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,3 +65,5 @@ end
 gem 'pry-rails'
 
 gem 'devise'
+
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
@@ -261,6 +264,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rails_12factor
   rspec-rails (~> 4.0.0)
   sass-rails (~> 5)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -18,14 +18,11 @@ class PostsController < ApplicationController
     url = url.last(11)
     @post.image = url
 
-    respond_to do |format|
-      if @post.save
-        format.html { redirect_to @post, notice: 'Post was successfully created.' }
-        format.json { render :show, status: :created, location: @post }
-      else
-        format.html { render :new }
-        format.json { render json: @post.errors, status: :unprocessable_entity }
-      end
+    if @post.valid?
+      @post.save
+      redirect_to root_path
+    else
+      render 'new'
     end
   end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,5 @@
 class Post < ApplicationRecord
-  validates :text, presence: true
+  validates :image, :text, presence: true
   belongs_to :user
   has_many :comments
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,11 @@
 <div class="contents row">
   <div class="container">
     <h2>Log in</h2>
+    <%# ログイン時のエラーメッセージ  %>
+    <div class='login-flash-message'>
+      <%= flash[:notice] %>
+      <%= flash[:alert] %>
+    </div>
     <%= form_with model: @user, url: user_session_path, id: 'new_user', class: 'new_user', local: true do |f| %>
       <div class="field">
         <%= f.label :email %><br />

--- a/app/views/layouts/_error_messages.html.erb
+++ b/app/views/layouts/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if model.errors.any? %>
+<div class="error-alert">
+  <ul>
+    <% model.errors.full_messages.each do |message| %>
+    <li class='error-message'><%= message %></li>
+    <% end %>
+  </ul>
+</div>
+<% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,7 +1,7 @@
-<%= form_with(model: post, local: true) do |form| %>
-      <%= form.text_field :image, placeholder: "動画Url" %>
-      <%= form.text_field :question1, placeholder: "Q. この動画から最も学べたことはなんですか？" %>
-      <%= form.text_field :question2, placeholder: "Q. 学んだことを実生活にどのように活かしていこうと思いますか？" %>
-      <%= form.text_area :text, placeholder: "アウトプットをご自由にご記入ください", rows: "10" %>
-      <%= form.submit "SEND" %>
-    <% end %>
+<%= form_with(model: @post, local: true) do |form| %>
+  <%= form.text_field :image, placeholder: "動画Url" %>
+  <%= form.text_field :question1, placeholder: "Q. この動画から最も学べたことはなんですか？" %>
+  <%= form.text_field :question2, placeholder: "Q. 学んだことを実生活にどのように活かしていこうと思いますか？" %>
+  <%= form.text_area :text, placeholder: "アウトプットをご自由にご記入ください", rows: "10" %>
+  <%= form.submit "SEND" %>
+<% end %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,6 +1,11 @@
 <div class="contents row">
   <div class="container">
-    <h3>アウトプットする</h3>
-    <%= render partial: "form", locals: { post: @post } %>
+    <%= form_with(model: @post, local: true) do |form| %>
+      <h3>
+        投稿する
+      </h3>
+      <%= render 'layouts/error_messages', model: form.object %>
+      <%= render partial: "form", locals: { form: form } %>
+    <% end %>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,7 +1,6 @@
 <div class="contents row">
   <div class="content_post">
   <p>
-    <strong>Youtube url:</strong>
     <iframe width="560" height="315" src="https://www.youtube.com/embed/<%= @post.image %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
   </p>
     <% if user_signed_in? && current_user.id == @post.user_id %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module BizTubeOutput
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    # 日本語の言語設定
+    config.i18n.default_locale = :ja
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,142 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザ
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントは凍結されています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: アカウント登録もしくはログインしてください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: あなたのメール変更（%{email}）のお知らせいたします。
+        subject: メール変更完了。
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されたことを通知します。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントの凍結解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか?
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか?
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントが凍結されているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか?
+        didn_t_receive_unlock_instructions: アカウントの凍結解除方法のメールを受け取っていませんか?
+        forgot_your_password: パスワードを忘れましたか?
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントの凍結解除方法を再送する
+      send_instructions: アカウントの凍結解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントを凍結解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: は凍結されていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,9 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+      post:
+        text: テキスト
+        image: 動画URL
+        user: ユーザー

--- a/db/migrate/20200925112632_create_posts.rb
+++ b/db/migrate/20200925112632_create_posts.rb
@@ -1,7 +1,7 @@
 class CreatePosts < ActiveRecord::Migration[6.0]
   def change
     create_table :posts do |t|
-      t.string :image, null: false
+      t.text :image, null: false
       t.text :text, null: false
       t.text :question1
       t.text :question2

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 2020_09_30_072036) do
 
-  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "post_id"
     t.text "text"
@@ -22,8 +22,8 @@ ActiveRecord::Schema.define(version: 2020_09_30_072036) do
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
-  create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "image", null: false
+  create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.text "image", null: false
     t.text "text", null: false
     t.text "question1"
     t.text "question2"
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 2020_09_30_072036) do
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "nickname", default: "", null: false

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :post do
+    text {Faker::Lorem.sentence}
+    image {Faker::Lorem.sentence}
+    question1 {Faker::Lorem.sentence}
+    question2 {Faker::Lorem.sentence}
+    association :user 
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -15,22 +15,22 @@ RSpec.describe Post, type: :model do
       it 'ログインしていないとアウトプットできない' do
         @post.user = nil
         @post.valid?
-        expect(@post.errors.full_messages).to include('User must exist')
+        expect(@post.errors.full_messages).to include('ユーザーを入力してください')
       end
       it "テキストがないとアウトプットは保存できない" do
         @post.text = ""
         @post.valid?
-        expect(@post.errors.full_messages).to include("Text can't be blank")
+        expect(@post.errors.full_messages).to include("テキストを入力してください")
       end  
       it "imageがないとアウトプットは保存できない" do
         @post.image = ""
         @post.valid?
-        expect(@post.errors.full_messages).to include("Image can't be blank")
+        expect(@post.errors.full_messages).to include("動画URLを入力してください")
       end   
       it "ユーザーが紐付いていないとアウトプットは保存できない" do
         @post.user = nil
         @post.valid?
-        expect(@post.errors.full_messages).to include("User must exist")
+        expect(@post.errors.full_messages).to include("ユーザーを入力してください")
       end
     end
   end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+  before do
+    @post = FactoryBot.build(:post)
+  end
+
+  describe 'アウトプットの保存' do
+    context "アウトプットが保存できる場合" do
+      it "画像とテキストがあればアウトプットは保存される" do
+        expect(@post).to be_valid
+      end
+    end
+    context "アウトプットが保存できない場合" do
+      it 'ログインしていないとアウトプットできない' do
+        @post.user = nil
+        @post.valid?
+        expect(@post.errors.full_messages).to include('User must exist')
+      end
+      it "テキストがないとアウトプットは保存できない" do
+        @post.text = ""
+        @post.valid?
+        expect(@post.errors.full_messages).to include("Text can't be blank")
+      end  
+      it "imageがないとアウトプットは保存できない" do
+        @post.image = ""
+        @post.valid?
+        expect(@post.errors.full_messages).to include("Image can't be blank")
+      end   
+      it "ユーザーが紐付いていないとアウトプットは保存できない" do
+        @post.user = nil
+        @post.valid?
+        expect(@post.errors.full_messages).to include("User must exist")
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,40 +24,40 @@ describe User do
       it "nicknameが空だと登録できない" do
         @user.nickname = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname can't be blank")
+        expect(@user.errors.full_messages).to include("ニックネームを入力してください")
       end
       it "nicknameが7文字以上であれば登録できない" do
         @user.nickname = 'aaaaaaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname is too long (maximum is 6 characters)")
+        expect(@user.errors.full_messages).to include("ニックネームは6文字以内で入力してください")
       end
       it "emailが空では登録できない" do
         @user.email = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email can't be blank")
+        expect(@user.errors.full_messages).to include("Eメールを入力してください")
       end
       it "重複したemailが存在する場合登録できない" do
         @user.save
         another_user = FactoryBot.build(:user)
         another_user.email = @user.email
         another_user.valid?
-        expect(another_user.errors.full_messages).to include('Email has already been taken')
+        expect(another_user.errors.full_messages).to include('Eメールはすでに存在します')
       end
       it "emailは@が含まれていないと登録できない" do
         @user.email = 'aaaaaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Email is invalid')
+        expect(@user.errors.full_messages).to include('Eメールは不正な値です')
       end
       it "passwordが空では登録できない" do
         @user.password = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password can't be blank")
+        expect(@user.errors.full_messages).to include("パスワードを入力してください")
       end
       it "passwordが5文字以下であれば登録できない" do
         @user.password = 'aaaa'
         @user.password_confirmation = 'aaaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
+        expect(@user.errors.full_messages).to include('パスワードは6文字以上で入力してください')
       end
       # it "passwordは半角英数字混合でないと登録できない" do
       #   @user.password = 'bbbaaa'
@@ -69,7 +69,7 @@ describe User do
         @user.password = 'aaaaaa'
         @user.password_confirmation = ' '
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+        expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
       end
     end
   end


### PR DESCRIPTION
"# 実装概要
url付きでアウトプットが投稿できるように実装し、単体テストを行う。

# 実装方針
- ブランチを作成する
- アウトプット投稿機能を実装する
- モデルの単体テストコードも書く
- しっかり確認したらデプロイする

# 実装の条件
- ログインしているユーザーだけが、投稿ページへ遷移できること
- (url)は1つ必須であること
- textが必須であること
- エラーハンドリングができていること（適切では無い値が入力された場合、情報は保存されず、エラーメッセージを出力させる）

# 補足情報
- カテゴリー選択の実装をする際は、以下のカリキュラムを参考にする
 - [補足カリキュラム](https://master.tech-camp.in/curriculums/4999)
- 配布しているビューファイルのname属性などは、初期値として「hoge」と設定しているため、実装する際には自身のDB設計などに合わせて変更すること。

# 注意事項
- Rubocopを実行すること。
- 機能毎に、commitとpushを行うこと。"